### PR TITLE
fix(ci): relax SDK version requirement to 10.0.100

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.103",
-    "rollForward": "latestMajor",
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
## Problem
GitHub Actions workflow `deploy` is failing because `global.json` requires exact SDK version 10.0.103, but GitHub Actions runners currently have 10.0.102 installed.

**Failed run:** https://github.com/Atypical-Consulting/BlazorMVU/actions/runs/22495404386

## Solution
Changed `global.json` to require SDK 10.0.100 with `rollForward: latestFeature` policy. This allows any 10.0.x SDK >= 10.0.100 to be used, making CI more resilient to SDK version updates.

## Changes
- `global.json`: Changed version from 10.0.103 to 10.0.100
- `global.json`: Changed rollForward from latestMajor to latestFeature (more appropriate for patch/feature rollForward)

**Auto-fix PR created by Ritchie 🛠️ (CTO)**