### PR TITLE
fix(ci): update dotnet-version from 9.0.x to 10.0.x

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
           
       # Install .NET Wasm-Tools
       - name: Install .NET WebAssembly Tools


### PR DESCRIPTION
## Summary

- Updates `dotnet-version` from `9.0.x` to `10.0.x` in the `gh-pages.yml` workflow
- The `global.json` requires SDK `10.0.103`, but only `9.0.x` was being installed
- The runner's pre-installed `10.0.102` is one patch behind `10.0.103`, causing `dotnet workload install wasm-tools` to fail

## Root Cause

The `global.json` pins the SDK to `10.0.103` with `rollForward: "latestMajor"`. The workflow only installed `9.0.x`, and the runner's pre-installed `10.0.102` is lower than the required `10.0.103`. This caused the error:

```
Requested SDK version: 10.0.103
A compatible .NET SDK was not found.
```

## Fix

Changed `dotnet-version: 9.0.x` → `dotnet-version: 10.0.x` so `setup-dotnet` installs the latest 10.0.x SDK (>= 10.0.103).

## Test plan

- [ ] Verify the `github pages` workflow passes on this PR branch
- [ ] Confirm the demo site deploys successfully to GitHub Pages