### PR TITLE
fix(core): update TargetFramework to net10.0

### DIFF
--- a/src/BlazorMVU.Core/BlazorMVU.Core.csproj
+++ b/src/BlazorMVU.Core/BlazorMVU.Core.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <RootNamespace>BlazorMVU</RootNamespace>
 
     <!-- NuGet Package Properties -->


### PR DESCRIPTION
## Summary
- Update `BlazorMVU.Core` `TargetFramework` from `net9.0` to `net10.0`
- Update `LangVersion` from `12` to `13`

## Root Cause
`BlazorMVU.Core.csproj` targeted `net9.0` but referenced NuGet packages that require `net10.0`:
- `Microsoft.AspNetCore.Components.Web 10.0.3` — supports `net10.0` only
- `Microsoft.JSInterop 10.0.3` — supports `net10.0` only

This caused `NU1202` restore errors during CI publish, failing the **github pages** workflow.

The Demo and Tests projects already targeted `net10.0` — only Core was stale.

## Test plan
- [ ] CI publish step passes (the failing step from run #22520368195)
- [ ] GitHub Pages deployment completes successfully

Fixes the failure in https://github.com/Atypical-Consulting/BlazorMVU/actions/runs/22520368195