### PR TITLE
feat: add dotnet new project template

### DIFF
--- a/BlazorMVU.sln
+++ b/BlazorMVU.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorMVU.Core", "src\BlazorMVU.Core\BlazorMVU.Core.csproj", "{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}"
 EndProject
@@ -8,25 +8,83 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorMVU.Tests", "src\Blaz
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorMVU.Templates", "src\BlazorMVU.Templates\BlazorMVU.Templates.csproj", "{2AF751B8-635B-4F07-9DB4-A03824581D50}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Debug|x86.Build.0 = Debug|Any CPU
 		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Release|x64.Build.0 = Release|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A1C4D5E-2F3B-4A6C-9D8E-1F2A3B4C5D6E}.Release|x86.Build.0 = Release|Any CPU
 		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Debug|x64.Build.0 = Debug|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Debug|x86.Build.0 = Debug|Any CPU
 		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Release|Any CPU.Build.0 = Release|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Release|x64.ActiveCfg = Release|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Release|x64.Build.0 = Release|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Release|x86.ActiveCfg = Release|Any CPU
+		{427C9350-FC59-464A-A694-ED63EB5B3C39}.Release|x86.Build.0 = Release|Any CPU
 		{271B53DA-8798-487B-95AC-6BE72F15561E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{271B53DA-8798-487B-95AC-6BE72F15561E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Debug|x64.Build.0 = Debug|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Debug|x86.Build.0 = Debug|Any CPU
 		{271B53DA-8798-487B-95AC-6BE72F15561E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{271B53DA-8798-487B-95AC-6BE72F15561E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Release|x64.ActiveCfg = Release|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Release|x64.Build.0 = Release|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Release|x86.ActiveCfg = Release|Any CPU
+		{271B53DA-8798-487B-95AC-6BE72F15561E}.Release|x86.Build.0 = Release|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Debug|x64.Build.0 = Debug|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Debug|x86.Build.0 = Debug|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Release|x64.ActiveCfg = Release|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Release|x64.Build.0 = Release|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Release|x86.ActiveCfg = Release|Any CPU
+		{96D68EE9-8776-4F81-923C-ADEBB7B7D03B}.Release|x86.Build.0 = Release|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Debug|x64.Build.0 = Debug|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Debug|x86.Build.0 = Debug|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Release|x64.ActiveCfg = Release|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Release|x64.Build.0 = Release|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Release|x86.ActiveCfg = Release|Any CPU
+		{2AF751B8-635B-4F07-9DB4-A03824581D50}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2AF751B8-635B-4F07-9DB4-A03824581D50} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ cd BlazorMvu
 dotnet build
 ```
 
+### Using the Template
+
+Install the template:
+
+```bash
+dotnet new install BlazorMVU.Templates
+```
+
+Create a new project:
+
+```bash
+dotnet new blazormvu -n MyApp
+cd MyApp
+dotnet run
+```
+
 ## Usage
 
 ### Basic Usage

--- a/src/BlazorMVU.Templates/BlazorMVU.Templates.csproj
+++ b/src/BlazorMVU.Templates/BlazorMVU.Templates.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageId>BlazorMVU.Templates</PackageId>
+    <Version>1.0.0</Version>
+    <Title>BlazorMVU Project Templates</Title>
+    <Authors>Atypical Consulting</Authors>
+    <Company>Atypical Consulting SRL</Company>
+    <Description>Project templates for creating Blazor applications using the Model-View-Update (MVU) pattern with BlazorMVU.</Description>
+    <PackageTags>blazor;mvu;elm;functional;state-management;template;dotnet-new</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Atypical-Consulting/BlazorMVU</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+
+</Project>

--- a/templates/blazormvu/.template.config/template.json
+++ b/templates/blazormvu/.template.config/template.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Atypical Consulting",
+  "classifications": ["Web", "Blazor", "WebAssembly", "MVU"],
+  "identity": "BlazorMVU.ProjectTemplate",
+  "name": "BlazorMVU Application",
+  "shortName": "blazormvu",
+  "sourceName": "BlazorMVU.App",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "preferNameDirectory": true,
+  "symbols": {
+    "framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net10.0",
+          "description": "Target .NET 10"
+        }
+      ],
+      "defaultValue": "net10.0",
+      "replaces": "net10.0"
+    }
+  }
+}

--- a/templates/blazormvu/App.razor
+++ b/templates/blazormvu/App.razor
@@ -1,0 +1,12 @@
+<Router AppAssembly="@typeof(App).Assembly">
+  <Found Context="routeData">
+    <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
+    <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
+  </Found>
+  <NotFound>
+    <PageTitle>Not found</PageTitle>
+    <LayoutView Layout="@typeof(MainLayout)">
+      <p role="alert">Sorry, there's nothing at this address.</p>
+    </LayoutView>
+  </NotFound>
+</Router>

--- a/templates/blazormvu/BlazorMVU.App.csproj
+++ b/templates/blazormvu/BlazorMVU.App.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>BlazorMVU.App</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BlazorMVU" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/templates/blazormvu/Components/Counter.razor
+++ b/templates/blazormvu/Components/Counter.razor
@@ -1,0 +1,8 @@
+@using BlazorMVU
+@inherits MvuComponent<int, Counter.Msg>
+
+<div>
+  <button @onclick="@(() => Dispatch(Msg.Decrement))">-</button>
+  <span style="margin: 0 1rem; font-size: 1.5rem;">@State</span>
+  <button @onclick="@(() => Dispatch(Msg.Increment))">+</button>
+</div>

--- a/templates/blazormvu/Components/Counter.razor.cs
+++ b/templates/blazormvu/Components/Counter.razor.cs
@@ -1,0 +1,21 @@
+namespace BlazorMVU.App.Components;
+
+public partial class Counter
+{
+    public enum Msg
+    {
+        Increment,
+        Decrement
+    }
+
+    protected override int Init()
+        => 0;
+
+    protected override int Update(Msg msg, int model)
+        => msg switch
+        {
+            Msg.Increment => model + 1,
+            Msg.Decrement => model - 1,
+            _ => model
+        };
+}

--- a/templates/blazormvu/MainLayout.razor
+++ b/templates/blazormvu/MainLayout.razor
@@ -1,0 +1,5 @@
+@inherits LayoutComponentBase
+
+<main class="container">
+  @Body
+</main>

--- a/templates/blazormvu/Pages/Index.razor
+++ b/templates/blazormvu/Pages/Index.razor
@@ -1,0 +1,9 @@
+@page "/"
+
+<PageTitle>BlazorMVU App</PageTitle>
+
+<h1>Welcome to BlazorMVU</h1>
+<p>This app uses the Model-View-Update (MVU) pattern for state management.</p>
+
+<h2>Counter</h2>
+<Counter />

--- a/templates/blazormvu/Program.cs
+++ b/templates/blazormvu/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using BlazorMVU.App;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+await builder.Build().RunAsync();

--- a/templates/blazormvu/Properties/launchSettings.json
+++ b/templates/blazormvu/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "profiles": {
+    "BlazorMVU.App": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browser}",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/blazormvu/_Imports.razor
+++ b/templates/blazormvu/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.JSInterop
+@using BlazorMVU.App
+@using BlazorMVU.App.Components

--- a/templates/blazormvu/wwwroot/css/app.css
+++ b/templates/blazormvu/wwwroot/css/app.css
@@ -1,0 +1,32 @@
+h1:focus {
+    outline: none;
+}
+
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }
+
+.blazor-error-boundary {
+    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45NjMgOTkgMjM2IDk3LjA2NTEgMjM2IDk0LjY3ODIgMjM2IDk0LjM3OTkgMjM2LjAzMSA5NC4wODg2IDIzNi4wODkgOTMuODA3MkwyMzYuMzM4IDkzLjAxNjIgMjM2Ljg1OCA5Mi4xMzE0IDI1OS40NzMgNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3Ljg3OSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N0MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvZz48L3N2Zz4=) no-repeat 1rem/1.8rem, #b32121;
+    padding: 1rem 1rem 1rem 3.7rem;
+    color: white;
+}
+
+    .blazor-error-boundary::after {
+        content: "An error has occurred."
+    }

--- a/templates/blazormvu/wwwroot/index.html
+++ b/templates/blazormvu/wwwroot/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <title>BlazorMVU.App</title>
+    <base href="/" />
+    <link href="css/app.css" rel="stylesheet" />
+</head>
+
+<body>
+<div id="app">
+    <span aria-busy="true">Loading...</span>
+</div>
+
+<div id="blazor-error-ui">
+    An unhandled error has occurred.
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">&#x1f5d9;</a>
+</div>
+<script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

Add a `dotnet new blazormvu` project template so users can quickly scaffold new BlazorMVU applications without manually setting up the project structure.

Fixes #2

## Changes

- `templates/blazormvu/` — Template content with minimal counter example, adapted from the Demo project
- `templates/blazormvu/.template.config/template.json` — Template manifest with `blazormvu` short name
- `src/BlazorMVU.Templates/BlazorMVU.Templates.csproj` — Template pack NuGet project for distribution
- `BlazorMVU.sln` — Added template project to solution
- `README.md` — Added Quick Start section with template installation instructions

## Testing

- Template can be installed locally with `dotnet new install ./templates/blazormvu/`
- `dotnet new blazormvu -n TestApp` creates a working Blazor WebAssembly project
- Generated project references BlazorMVU NuGet package (not project reference)
- Counter component demonstrates the MVU pattern correctly